### PR TITLE
Fix for android build --release (fileUtils is not defined)

### DIFF
--- a/hooks/applyCustomConfig.js
+++ b/hooks/applyCustomConfig.js
@@ -13,7 +13,8 @@ var logger,
     et,
     plist,
     xcode,
-    tostr;
+    tostr,
+    fileUtils;
 
 // Other globals
 var hooksPath;
@@ -433,7 +434,7 @@ var applyCustomConfig = (function(){
                 // so if buildType="debug", want to overrwrite in build.xcconfig
                 if(item.name.match("CODE_SIGN_IDENTITY") && itemBuildType == "debug" && fileBuildType == "none" && !item.xcconfigEnforce){
                     doReplace();
-                }              
+                }
             }
         });
 


### PR DESCRIPTION
If you try to build for android with `--release`, `applyCustomConfig.js` will throw this error:

```
cordova-custom-config: Error loading dependencies (fileUtils is not defined) - attempting to resolve
```

Apparently the var declaration for `fileUtils` accidentally got deleted in this commit:

https://github.com/dpa99c/cordova-custom-config/commit/95cc8e2d7f8c34de27cd513c3cbe16b2c99eaff3

This PR adds the var declaration back again and fixes this issue.