### PR TITLE
Adding ability to remove nodes in AndroidManifest.xml via preferences 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.idea
+backup/*
+node_modules/*

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ For a list of possible manifest values see [http://developer.android.com/guide/t
 - `<preference>` elements in `config.xml` are used to set set attributes on existing elements in the `AndroidManifest.xml`.
     - e.g. `<preference name="android-manifest/@android:hardwareAccelerated" value="false" />`
     - will result in `AndroidManifest.xml`: `<manifest android:hardwareAccelerated="false">`
+- Sometimes there plugins set some defaults in AndroidManifest.xml that you may not want.
+  It is also possible to delete nodes using the preferences and the `delete="true"` attribute.
+  - e.g. `<preference name="android-manifest/uses-permission/[@android:name='android.permission.WRITE_CONTACTS']/@android:name" delete="true" />`
+  - will delete the existing node `<uses-permission android:name="android.permission.WRITE_CONTACTS" />`
 
 #### Android namespace attribute
 

--- a/hooks/applyCustomConfig.js
+++ b/hooks/applyCustomConfig.js
@@ -235,8 +235,11 @@ var applyCustomConfig = (function(){
             }
 
             if(item.type === 'preference') {
-                parentEl.attrib[childSelector.replace("@",'')] = data.attrib['value'];
-
+                if(data.attrib['delete'] === 'true') {
+                    root.remove(parentEl);
+                } else {
+                    parentEl.attrib[childSelector.replace("@",'')] = data.attrib['value'];
+                }
             } else {
                 //  if there can be multiple sibling elements, we need to select them by unique name
                 if(androidRootMultiplesByName.indexOf(childSelector) > -1){


### PR DESCRIPTION
I encountered a situation where a cordova plugin was adding an unnecessary permission to my AndroidManifest.xml and I wanted to remove that XML node. This pull request should help with that.