### PR TITLE
Bugfix: merge plist arrays instead of overriding them

### DIFF
--- a/hooks/applyCustomConfig.js
+++ b/hooks/applyCustomConfig.js
@@ -480,8 +480,11 @@ var applyCustomConfig = (function(){
             if (!value && item.data.tag === "string") {
               value = "";
             }
-            infoPlist[key] = value;
-            logger.verbose("Write to plist; key="+key+"; value="+tostr(value));
+            if (item.data.tag === "array") {
+              infoPlist[key] = Object.assign({}, infoPlist[key], value)
+            } else {
+              infoPlist[key] = value;
+            }
         });
 
         tempInfoPlist = plist.build(infoPlist);

--- a/hooks/applyCustomConfig.js
+++ b/hooks/applyCustomConfig.js
@@ -485,6 +485,7 @@ var applyCustomConfig = (function(){
             } else {
               infoPlist[key] = value;
             }
+            logger.verbose("Wrote to plist; key=" + key + "; value=" + tostr(infoPlist[key]));
         });
 
         tempInfoPlist = plist.build(infoPlist);

--- a/package.json
+++ b/package.json
@@ -43,5 +43,9 @@
     },
     "scripts": {
         "test": "jshint hooks"
+    },
+    "engineStrict": true,
+    "engines": {
+        "node": ">=4.0.0"
     }
 }


### PR DESCRIPTION
This fixes #51

The facebook4 plugin has those `LSApplicationQueriesSchemes` in its `plugin.xml`

```xml
<config-file target="*-Info.plist" parent="LSApplicationQueriesSchemes">
  <array>
     <string>fbapi</string>
     <string>fb-messenger-api</string>
     <string>fbauth2</string>
     <string>fbshareextension</string>
   </array>
</config-file>
```

If your app also has entries for `LSApplicationQueriesSchemes` then they are now merged with whatever is already there:

You apps custom config:
```xml
<config-file parent="LSApplicationQueriesSchemes" target="*-Info.plist">
  <array>
    <string>myapp</string>
    <string>myapp2</string>
    <string>myapp3</string>
  </array>
</config-file>
```

Will now be correctly result in:

```xml
<key>LSApplicationQueriesSchemes</key>
    <dict>
      <key>0</key>
      <string>myapp</string>
      <key>1</key>
      <string>myapp2</string>
      <key>2</key>
      <string>myapp3</string>
      <key>3</key>
      <string>fbapi</string>
      <key>4</key>
      <string>fb-messenger-api</string>
      <key>5</key>
      <string>fbauth2</string>
      <key>6</key>
      <string>fbshareextension</string>
      <key>7</key>
      <string>comgooglemaps</string>
    </dict>
```

This also improves the logging of a plist change. It will output the result of the merge process instead of only the new values.