### PR TITLE
Fix: Merge plist arrays properly

### DIFF
--- a/hooks/applyCustomConfig.js
+++ b/hooks/applyCustomConfig.js
@@ -481,7 +481,7 @@ var applyCustomConfig = (function(){
               value = "";
             }
             if (item.data.tag === "array") {
-              infoPlist[key] = Object.assign({}, infoPlist[key], value)
+              infoPlist[key] = [...new Set([...infoPlist[key], ...value])]
             } else {
               infoPlist[key] = value;
             }

--- a/package.json
+++ b/package.json
@@ -43,9 +43,5 @@
     },
     "scripts": {
         "test": "jshint hooks"
-    },
-    "engineStrict": true,
-    "engines": {
-        "node": ">=4.0.0"
-    }
+    }    
 }


### PR DESCRIPTION
This fixes #92 and originally #51 