### PR TITLE
Added support for #include statements in xcconfig files

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ config.xml:
 - If a preference value doesn't already exist in the corresponding `.xcconfig` file, you can force its addition by setting the preference attribute `xcconfigEnforce="true"`.
 This will append it to the corresponding .xcconfig` file.
      - e.g `<custom-preference name="ios-XCBuildConfiguration-SOME_PREFERENCE" value="Some value" buildType="debug" xcconfigEnforce="true" />`
+- Dependencies on additional `.xcconfig` files be added to a project by using `#include` statements. Note, the buildType attribute applies as stated above, however, xcconfigEnforce has no effect on `#include` statements as it is possible to have multiple `#include` statemnets in a single `.xcconfig` file.
+    - e.g. `<custom-preference name="ios-XCBuildConfiguration-#INCLUDE" value="/path/to/external/dependency/additional_config.xcconfig" />`. 
 - A backup copy of any modified `.xcconfig` file will be made in 'plugins/cordova-custom-config/backup/ios'. By default, these backups will be restored prior to the next `prepare` operation.
 - Auto-restore of the backups can be disabled by setting `<custom-preference name="cordova-custom-config-autorestore" value="false" />` in the `config.xml`.
 - Preference names and values will not be quote-escaped in `.xcconfig` files, so the `quote` attribute has no effect on them.

--- a/hooks/applyCustomConfig.js
+++ b/hooks/applyCustomConfig.js
@@ -887,7 +887,7 @@ var applyCustomConfig = (function(){
                 // If item's target build type matches the xcconfig build type
                 if(itemBuildType === fileBuildType)
                 {
-                    // If config.xml contains any #include statements for use the in xcconfig files.
+                    // If config.xml contains any #include statements for use in .xcconfig files
                     if(item.name.match("#INCLUDE") && !fileContents.match(value)) {
                         fileContents += '\n#include "' + value + '"';
                         modified = true;

--- a/hooks/applyCustomConfig.js
+++ b/hooks/applyCustomConfig.js
@@ -885,14 +885,21 @@ var applyCustomConfig = (function(){
                 };
 
                 // If item's target build type matches the xcconfig build type
-                if(itemBuildType === fileBuildType){
-                    // If file contains the item, replace it with configured value
-                    if(fileContents.match(escapedName) && item.xcconfigEnforce !== "false"){
-                        doReplace();
-                    }else // presence of item is being enforced, so add it to the relevant .xcconfig
-                    if(item.xcconfigEnforce === "true"){
-                        fileContents += "\n"+name+" = "+value;
+                if(itemBuildType === fileBuildType)
+                {
+                    // If config.xml contains any #include statements for use the in xcconfig files.
+                    if(item.name.match("#INCLUDE") && !fileContents.match(value)) {
+                        fileContents += '\n#include "' + value + '"';
                         modified = true;
+                    } else {
+                        // If file contains the item, replace it with configured value
+                        if (fileContents.match(escapedName) && item.xcconfigEnforce !== "false") {
+                            doReplace();
+                        } else // presence of item is being enforced, so add it to the relevant .xcconfig
+                        if (item.xcconfigEnforce === "true") {
+                            fileContents += "\n" + name + " = " + value;
+                            modified = true;
+                        }
                     }
                 }else
                 // if item is a Debug CODE_SIGNING_IDENTITY, this is a special case: Cordova places its default Debug CODE_SIGNING_IDENTITY in build.xcconfig (not build-debug.xcconfig)


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
This change adds support for #include statements in .xcconfig files.  For any project that relies on external dependencies it's currently impossible to import them using the existing configuration options.

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [x] Regression testing has been carried out for existing functionality
- [x] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What testing has been done on the changes in the PR?
Dev testing.

## What testing has been done on existing functionality?
Regression testing.