### PR TITLE
Support cordova-ios 8+ project layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ Therefore a new major version of this plugin (v5) has been released to support t
         - This can be overridden by explicitly setting the `parse_unprefixed` preference
             - `<preference name="cordova-custom-config-parse_unprefixed" value="true" />`
 
+## cordova-ios 8+ compatibility
+
+`cordova-ios@8` changed the iOS project directory structure. Previously, platform files (such as `Info.plist`, entitlements, etc.) were located under a directory named after the project (e.g. `platforms/ios/MyApp/MyApp-Info.plist`). In cordova-ios 8+, these files are located under `platforms/ios/App/App-Info.plist`.
+
+This plugin now automatically detects which layout is present:
+- If `platforms/ios/App/` exists, the new layout is used.
+- Otherwise, the legacy layout using the project name from `config.xml` is used.
+
+No changes to your `config.xml` are required — the `target="*-Info.plist"` wildcard pattern continues to work with both layouts.
+
 ## Remote build environments
 
 This plugin is intended for the automated application of custom configuration to native platform projects in a **local build environment**.

--- a/hooks/applyCustomConfig.js
+++ b/hooks/applyCustomConfig.js
@@ -141,7 +141,7 @@ var applyCustomConfig = (function(){
 
 
     // Variables
-    var applyCustomConfig = {}, rootdir, plugindir, context, configXml, projectName, settings = {}, updatedFiles = {};
+    var applyCustomConfig = {}, rootdir, plugindir, context, configXml, projectName, iosAppDirName, settings = {}, updatedFiles = {};
 
     var preferencesData;
     var resources;
@@ -1029,31 +1029,31 @@ var applyCustomConfig = (function(){
             var targetFilePath;
             if (platform === 'ios') {
                 if (targetName.indexOf("Info.plist") > -1) {
-                    targetName =  projectName + '-Info.plist';
-                    targetFilePath = path.join(platformPath, projectName, targetName);
+                    targetName =  iosAppDirName + '-Info.plist';
+                    targetFilePath = path.join(platformPath, iosAppDirName, targetName);
                     ensureBackup(targetFilePath, platform, targetName);
                     updateIosPlist(targetFilePath, configItems);
                 }else if (targetName === "project.pbxproj") {
-                    targetFilePath = path.join(platformPath, projectName + '.xcodeproj', targetName);
+                    targetFilePath = path.join(platformPath, iosAppDirName + '.xcodeproj', targetName);
                     ensureBackup(targetFilePath, platform, targetName);
                     updateIosPbxProj(targetFilePath, configItems);
                     updateXCConfigs(configItems, platformPath);
                 }else if (targetName.indexOf("Entitlements-Release.plist") > -1) {
-                    targetFilePath = path.join(platformPath, projectName, targetName);
+                    targetFilePath = path.join(platformPath, iosAppDirName, targetName);
                     ensureBackup(targetFilePath, platform, targetName);
                     updateIosPlist(targetFilePath, configItems);
                 }else if (targetName.indexOf("Entitlements-Debug.plist") > -1) {
-                    targetFilePath = path.join(platformPath, projectName, targetName);
+                    targetFilePath = path.join(platformPath, iosAppDirName, targetName);
                     ensureBackup(targetFilePath, platform, targetName);
                     updateIosPlist(targetFilePath, configItems);
                 }else if (targetName.indexOf("Prefix.pch") > -1) {
-                    targetName =  projectName + '-Prefix.pch';
-                    targetFilePath = path.join(platformPath, projectName, targetName);
+                    targetName =  iosAppDirName + '-Prefix.pch';
+                    targetFilePath = path.join(platformPath, iosAppDirName, targetName);
                     ensureBackup(targetFilePath, platform, targetName);
                     updateIosPch(targetFilePath, configItems);
                 }else if (targetName.indexOf("asset_catalog") > -1) {
                     targetName =  targetName.split('.')[1];
-                    var targetDirPath = path.join(platformPath, projectName, "Images.xcassets", targetName+".imageset");
+                    var targetDirPath = path.join(platformPath, iosAppDirName, "Images.xcassets", targetName+".imageset");
                     deployAssetCatalog(targetName, targetDirPath, configItems);
                 }
 
@@ -1120,6 +1120,15 @@ var applyCustomConfig = (function(){
 
         configXml = fileUtils.getConfigXml();
         projectName = fileUtils.getProjectName();
+
+        // Detect cordova-ios 8+ layout (App/) vs legacy layout (ProjectName/)
+        var newLayoutPath = path.join(rootdir, 'platforms', 'ios', 'App');
+        if(fileUtils.directoryExists(newLayoutPath)){
+            iosAppDirName = 'App';
+        }else{
+            iosAppDirName = projectName;
+        }
+
         settings = fileUtils.getSettings();
         var runHook = settings.hook ? settings.hook : defaultHook;
 

--- a/hooks/restoreBackups.js
+++ b/hooks/restoreBackups.js
@@ -23,18 +23,18 @@ var restoreBackups = (function(){
     /**********************
      * Internal properties
      *********************/
-    var restoreBackups = {}, context, projectName, logFn, settings;
+    var restoreBackups = {}, context, projectName, iosAppDirName, logFn, settings;
 
     var PLATFORM_CONFIG_FILES = {
         "ios":{
-            "{projectName}-Info.plist": "{projectName}/{projectName}-Info.plist",
-            "project.pbxproj": "{projectName}.xcodeproj/project.pbxproj",
+            "{iosAppDirName}-Info.plist": "{iosAppDirName}/{iosAppDirName}-Info.plist",
+            "project.pbxproj": "{iosAppDirName}.xcodeproj/project.pbxproj",
             "build.xcconfig": "cordova/build.xcconfig",
             "build-extras.xcconfig": "cordova/build-extras.xcconfig",
             "build-debug.xcconfig": "cordova/build-debug.xcconfig",
             "build-release.xcconfig": "cordova/build-release.xcconfig",
-            "Entitlements-Release.plist": "{projectName}/Entitlements-Release.plist",
-            "Entitlements-Debug.plist": "{projectName}/Entitlements-Debug.plist"
+            "Entitlements-Release.plist": "{iosAppDirName}/Entitlements-Release.plist",
+            "Entitlements-Debug.plist": "{iosAppDirName}/Entitlements-Debug.plist"
         },
         "android":{
             "AndroidManifest.xml": "AndroidManifest.xml"
@@ -63,7 +63,7 @@ var restoreBackups = (function(){
     }
 
     function parseProjectName(fileName){
-        return fileName.replace(/{(projectName)}/g, projectName);
+        return fileName.replace(/{projectName}/g, projectName).replace(/{iosAppDirName}/g, iosAppDirName);
     }
 
     // Script operations are complete, so resolve deferred promises
@@ -85,6 +85,15 @@ var restoreBackups = (function(){
         context = ctx;
 
         projectName = fileUtils.getProjectName();
+
+        // Detect cordova-ios 8+ layout (App/) vs legacy layout (ProjectName/)
+        var newLayoutPath = path.join(cwd, 'platforms', 'ios', 'App');
+        if(fileUtils.directoryExists(newLayoutPath)){
+            iosAppDirName = 'App';
+        }else{
+            iosAppDirName = projectName;
+        }
+
         logFn = context.hook === "before_plugin_uninstall" ? logger.log : logger.verbose;
 
         settings = fileUtils.getSettings();


### PR DESCRIPTION
cordova-ios 8 changed the iOS platform directory structure from <ProjectName>/<ProjectName>-Info.plist to App/App-Info.plist.

Auto-detect which layout is present and use the correct paths for Info.plist, project.pbxproj, entitlements, and other iOS files. Both old and new layouts are supported.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [x] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

I've built my project and all of the expected `Info.plist` changes were present. It didn't work before.

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

My testing was in an existing project, but I haven't tested with an older version of `cordova-ios`.

## Other information

This doesn't appear to be as elegant as the other PRs that used `cordova-ios` API but it does appear to work and solves my problem!